### PR TITLE
Feature/year api query

### DIFF
--- a/src/data_hub/tnris_org/models.py
+++ b/src/data_hub/tnris_org/models.py
@@ -169,6 +169,10 @@ class TnrisTraining(models.Model):
         auto_now=True
     )
 
+    @property
+    def year(self):
+        return self.start_date_time.strftime("%Y")
+
     def __str__(self):
         return self.title
 
@@ -260,6 +264,10 @@ class TnrisForumTraining(models.Model):
         'Last Modified',
         auto_now=True
     )
+
+    @property
+    def year(self):
+        return self.start_date_time.strftime("%Y")
 
     def __str__(self):
         return self.title

--- a/src/data_hub/tnris_org/serializers.py
+++ b/src/data_hub/tnris_org/serializers.py
@@ -5,6 +5,12 @@ from datetime import datetime
 
 
 class TnrisTrainingSerializer(serializers.ModelSerializer):
+    # add serializer method field 'year' to api
+    year = serializers.SerializerMethodField('get_training_year')
+
+    def get_training_year(self, obj):
+        return obj.start_date_time.strftime("%Y")
+
     class Meta:
         model = TnrisTraining
         fields = '__all__'
@@ -15,6 +21,12 @@ class TnrisTrainingSerializer(serializers.ModelSerializer):
 
 
 class TnrisForumTrainingSerializer(serializers.ModelSerializer):
+    # add serializer method field 'year' to api
+    year = serializers.SerializerMethodField('get_training_year')
+
+    def get_training_year(self, obj):
+        return obj.start_date_time.strftime("%Y")
+
     class Meta:
         model = TnrisForumTraining
         fields = '__all__'

--- a/src/data_hub/tnris_org/serializers.py
+++ b/src/data_hub/tnris_org/serializers.py
@@ -5,15 +5,21 @@ from datetime import datetime
 
 
 class TnrisTrainingSerializer(serializers.ModelSerializer):
-    # add serializer method field 'year' to api
-    year = serializers.SerializerMethodField('get_training_year')
-
-    def get_training_year(self, obj):
-        return obj.start_date_time.strftime("%Y")
-
     class Meta:
         model = TnrisTraining
-        fields = '__all__'
+        fields = ('training_id',
+                  'year', # models.py property method (field does not exist in db)
+                  'start_date_time',
+                  'end_date_time',
+                  'title',
+                  'instructor',
+                  'cost',
+                  'registration_open',
+                  'instructor_bio',
+                  'description',
+                  'created',
+                  'last_modified',
+                  'public',)
 
     # format date/time for api rest endpoint to use on front end
     start_date_time = serializers.DateTimeField(format="%A, %B %d %I:%M %p")
@@ -21,15 +27,26 @@ class TnrisTrainingSerializer(serializers.ModelSerializer):
 
 
 class TnrisForumTrainingSerializer(serializers.ModelSerializer):
-    # add serializer method field 'year' to api
-    year = serializers.SerializerMethodField('get_training_year')
-
-    def get_training_year(self, obj):
-        return obj.start_date_time.strftime("%Y")
-
     class Meta:
         model = TnrisForumTraining
-        fields = '__all__'
+        fields = ('training_id',
+                  'year', # models.py property method (field does not exist in db)
+                  'start_date_time',
+                  'end_date_time',
+                  'training_day',
+                  'title',
+                  'instructor',
+                  'cost',
+                  'registration_open',
+                  'location',
+                  'room',
+                  'max_students',
+                  'instructor_bio',
+                  'description',
+                  'teaser',
+                  'created',
+                  'last_modified',
+                  'public',)
 
     # format date/time for api rest endpoint to use on front end
     start_date_time = serializers.DateTimeField(format="%A, %B %d %I:%M %p")

--- a/src/data_hub/tnris_org/urls.py
+++ b/src/data_hub/tnris_org/urls.py
@@ -24,9 +24,9 @@ router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'training/?', TnrisTrainingViewSet, base_name="TnrisTraining")
 router.register(r'forum_training/?', TnrisForumTrainingViewSet, base_name="TnrisForumTraining")
 
-schema_view = get_swagger_view(title='Maps API')
+schema_view = get_swagger_view(title='TNRIS.org API')
 
 urlpatterns = [
     path('', include(router.urls)),
-    path('schema/', schema_view)
+    # path('schema/', schema_view)
 ]


### PR DESCRIPTION
effort to get 'fake' serializer method field / models.py property field to be query-able at the rest endpoint. django only wants to query actual database fields. decided to go ahead and show this 'year' field in the rest endpoint, but parse all trainings by year on the front end if necessary (this will be necessary for forum trainings). 

cannot directly query the tnris_training or tnris_forum_training tables with api url queries (ex: http://api.tnris.org/api/v1/tnris_org/training/?year=2019)