### PR TITLE
setup extension recognition to apply proper content type to document uploads

### DIFF
--- a/src/data_hub/tnris_org/forms.py
+++ b/src/data_hub/tnris_org/forms.py
@@ -128,11 +128,24 @@ class DocumentForm(forms.ModelForm):
 
     # function to upload document to s3 and update dbase link
     def handle_doc(self, field, file):
+        # set proper content type base on file extension
+        content_type = 'binary/octet-stream'
+        ext = os.path.splitext(str(file))[-1]
+        ext_ref = {
+            '.pdf': 'application/pdf',
+            '.zip': 'application/zip',
+            '.jpg': 'image',
+            '.png': 'image',
+            '.wav': 'audio/x-wav'
+        }
+        if ext.lower() in ext_ref.keys():
+            content_type = ext_ref[ext.lower()]
         # upload image
         key = "documents/%s" % (file)
         response = self.client.put_object(
             Bucket='tnris-org-static',
             ACL='public-read',
+            ContentType=content_type,
             Key=key,
             Body=file
         )


### PR DESCRIPTION
added file extension interpreting and application of content type to document uploads for tnris.org

not utilizing the content type yielded pdf files to download in browser opposed to viewed

closes #17