### PR TITLE
lidar 3d buildings admin, form, x-large supplemental

### DIFF
--- a/src/data_hub/lcd/admin.py
+++ b/src/data_hub/lcd/admin.py
@@ -82,6 +82,8 @@ class CollectionAdmin(admin.ModelAdmin):
                        'delete_supplemental_report_url',
                        'lidar_breaklines_url',
                        'delete_lidar_breaklines_url',
+                       'lidar_buildings_url',
+                       'delete_lidar_buildings_url',
                        'tile_index_url',
                        'delete_tile_index_url')
         }),

--- a/src/data_hub/lcd/forms.py
+++ b/src/data_hub/lcd/forms.py
@@ -85,10 +85,12 @@ class CollectionForm(forms.ModelForm):
 
     supplemental_report_url = forms.FileField(required=False, widget=ZipfileWidget, help_text="Maximum filesize 75MB")
     lidar_breaklines_url = forms.FileField(required=False, widget=ZipfileWidget, help_text="Maximum filesize 75MB")
+    lidar_buildings_url = forms.FileField(required=False, widget=ZipfileWidget, help_text="Maximum filesize 75MB")
     tile_index_url = forms.FileField(required=False, widget=ZipfileWidget, help_text="Maximum filesize 75MB")
 
     delete_supplemental_report_url = forms.BooleanField(required=False)
     delete_lidar_breaklines_url = forms.BooleanField(required=False)
+    delete_lidar_buildings_url = forms.BooleanField(required=False)
     delete_tile_index_url = forms.BooleanField(required=False)
 
     # boto3 s3 object
@@ -297,6 +299,7 @@ class CollectionForm(forms.ModelForm):
         new_key_field = {}
         z_files = [('-supplemental-report.zip', 'supplemental_report_url'),
                    ('-lidar-breaklines.zip', 'lidar_breaklines_url'),
+                   ('-lidar-buildings.zip', 'lidar_buildings_url'),
                    ('-tile-index.zip', 'tile_index_url')]
         urlized_og_nm = og_name.lower().replace(', ', '-').replace(' & ', '-').replace(' ', '-').replace('(', '').replace(')', '').replace('\\', '-').replace('/', '-').replace('&', '').replace(',', '-')
         urlized_new_nm = self.cleaned_data['name'].lower().replace(', ', '-').replace(' & ', '-').replace(' ', '-').replace('(', '').replace(')', '').replace('\\', '-').replace('/', '-').replace('&', '').replace(',', '-')
@@ -347,7 +350,7 @@ class CollectionForm(forms.ModelForm):
         # check for files
         files = self.files
         image_fields = ['overview_image', 'thumbnail_image', 'natural_image', 'urban_image']
-        zipfile_fields = ['supplemental_report_url', 'lidar_breaklines_url', 'tile_index_url']
+        zipfile_fields = ['supplemental_report_url', 'lidar_breaklines_url', 'lidar_buildings_url', 'tile_index_url']
         # if files and field not marked for deletion then upload to s3
         for f in files:
             delete_checkbox = 'delete_' + f
@@ -367,6 +370,7 @@ class CollectionForm(forms.ModelForm):
                           'delete_urban_image',
                           'delete_supplemental_report_url',
                           'delete_lidar_breaklines_url',
+                          'delete_lidar_buildings_url',
                           'delete_tile_index_url']
         for d in deletion_flags:
             if self.cleaned_data[d] is True:
@@ -566,6 +570,7 @@ class XlargeSupplementalForm(forms.ModelForm):
 
     supplemental_choices = [
         ('lidar_breaklines_url', 'Lidar Breaklines'),
+        ('lidar_buildings_url', 'Lidar Buildings'),
         ('supplemental_report_url', 'Supplemental Report'),
         ('tile_index_url', 'Tile Index')
     ]

--- a/src/data_hub/lcd/templates/admin/includes/xlarge_supplemental_fieldset.html
+++ b/src/data_hub/lcd/templates/admin/includes/xlarge_supplemental_fieldset.html
@@ -16,14 +16,16 @@
       <p>
         <strong>Lidar Breaklines: </strong>"data.tnris.org/<--collection uuid-->/assets/<--lowercase dash separated collection name-->-lidar-breaklines.zip"
         <br>
+        <strong>Lidar Buildings: </strong>"data.tnris.org/<--collection uuid-->/assets/<--lowercase dash separated collection name-->-lidar-buildings.zip"
+        <br>
         <strong>Supplemental Report: </strong>"data.tnris.org/<--collection uuid-->/assets/<--lowercase dash separated collection name-->-supplemental-report.zip"
         <br>
         <strong>Tile Index: </strong>"data.tnris.org/<--collection uuid-->/assets/<--lowercase dash separated collection name-->-tile-index.zip"
       </p>
       <p style="padding-top:15px;">
         <strong>WARNING: </strong>When you choose from the dropdowns and press 'Save', this application <strong>will overwrite/update</strong>
-        the chosen Supplemental Type field for the chosen Collection within the database. The field is updated with a URL to the supplemental 
-        download zipfile uploaded to s3. Requires said file is named correctly (as outlined above) and already uploaded to the s3 bucket. This 
+        the chosen Supplemental Type field for the chosen Collection within the database. The field is updated with a URL to the supplemental
+        download zipfile uploaded to s3. Requires said file is named correctly (as outlined above) and already uploaded to the s3 bucket. This
         form will error if the file is misnamed or has not been uploaded yet.
         <br>
         After saving, zipfile deletion within the Collection change form will still function as normal.


### PR DESCRIPTION
added lidar_buildings_url to collections table in lcd.models; admin.py and forms.py changes for new lidar_buildings_url for normal collection form and for x-large supplemental form in master resources; etc.

closes issue #34