### PR TITLE
Feature/tnris org documents tiny preview bug

### DIFF
--- a/src/data_hub/tnris_org/admin.py
+++ b/src/data_hub/tnris_org/admin.py
@@ -52,7 +52,7 @@ class TnrisImageAdmin(admin.ModelAdmin):
         """.replace('{id}', htmlId)
         js = format_html(js)
         return format_html(
-            u'{0}<a style="cursor:pointer;border:solid 1px;padding:3px;" onclick="{1}Function();">COPY URL</a><input style="width:90%;margin-left:5px;" type="text" id="{2}" value="{3}" readonly>',
+            u'{0}<div style="margin-bottom:10px;"><a style="cursor:pointer;border:solid 1px;padding:3px;" onclick="{1}Function();">COPY URL</a></div><div><input style="width:90%;" type="text" id="{2}" value="{3}" readonly></input></div>',
             js,
             htmlId,
             htmlId,
@@ -89,7 +89,7 @@ class TnrisDocumentAdmin(admin.ModelAdmin):
         """.replace('{id}', htmlId)
         js = format_html(js)
         return format_html(
-            u'{0}<a style="cursor:pointer;border:solid 1px;padding:3px;" onclick="{1}Function();">COPY URL</a><input style="width:90%;margin-left:5px;" type="text" id="{2}" value="{3}" readonly>',
+            u'{0}<div style="margin-bottom:10px;"><a style="cursor:pointer;border:solid 1px;padding:3px;" onclick="{1}Function();">COPY URL</a></div><div><input style="width:90%;" type="text" id="{2}" value="{3}" readonly></input></div>',
             js,
             htmlId,
             htmlId,

--- a/src/data_hub/tnris_org/admin.py
+++ b/src/data_hub/tnris_org/admin.py
@@ -72,7 +72,7 @@ class TnrisDocumentAdmin(admin.ModelAdmin):
     model = TnrisDocument
     form = DocumentForm
     ordering = ('document_name',)
-    list_display = ('document_name', 'document_url_link', 'tiny_preview', 'created')
+    list_display = ('document_name', 'document_url_link', 'created')
     search_fields = ('document_name', 'document_url')
 
     def document_url_link(self, obj):
@@ -94,19 +94,6 @@ class TnrisDocumentAdmin(admin.ModelAdmin):
             htmlId,
             htmlId,
             obj.document_url
-        )
-
-    def tiny_preview(self, obj):
-        # tiny preview of .pdf files errors/breaks on page load when src is cached.
-        # this means all tiny previews display on hard reload, but .pdfs don't on
-        # normal reload. so, we append a current datetime query string to the request
-        # so the browser recognizes each load as a new request and doesn't load the
-        # cached version.
-        no_cache = str(datetime.today())
-        return format_html(
-            u'<embed style="max-width: 120px;" src="{0}?d={1}"></embed>',
-            obj.document_url,
-            no_cache
         )
 
 

--- a/src/data_hub/tnris_org/forms.py
+++ b/src/data_hub/tnris_org/forms.py
@@ -32,7 +32,7 @@ class PictureWidget(forms.widgets.Widget):
         if value is None:
             html = Template("""<input type="file" name="$name" id="id_$name"><label for="img_$name">Current: <a href="#">$link</a></label>""")
         else:
-            html = Template("""{0}<a style="cursor:pointer;border:solid 1px;padding:3px;margin-left:15px;" onclick="copyFunction();">COPY URL</a><input style="width:50%;margin-left:5px;" type="text" id="currentUrl" value="$link" readonly><br><img id="img_$name" src="$link"/>""".format(js))
+            html = Template("""{0}<a style="cursor:pointer;border:solid 1px;padding:3px;margin-left:15px;" onclick="copyFunction();">COPY URL</a><input style="width:50%;margin-left:5px;" type="text" id="currentUrl" value="$link" readonly></input><br><img id="img_$name" src="$link"/>""".format(js))
         return mark_safe(html.substitute(link=value,name=name))
 
 
@@ -51,7 +51,7 @@ class DocumentWidget(forms.widgets.Widget):
         if value is None:
             html = Template("""<input type="file" name="$name" id="id_$name"><label for="doc_$name">Current: <a href="#">$link</a></label>""")
         else:
-            html = Template("""{0}<a style="cursor:pointer;border:solid 1px;padding:3px;margin-left:15px;" onclick="copyFunction();">COPY URL</a><input style="width:50%;margin-left:5px;" type="text" id="currentUrl" value="$link" readonly><br><embed style="max-width:80%;max-height:600px;" src="$link"></embed>""".format(js))
+            html = Template("""{0}<a style="cursor:pointer;border:solid 1px;padding:3px;margin-left:15px;" onclick="copyFunction();">COPY URL</a><input style="width:50%;margin-left:5px;" type="text" id="currentUrl" value="$link" readonly></input>""".format(js))
         return mark_safe(html.substitute(link=value,name=name))
 
 
@@ -69,7 +69,7 @@ class ImageForm(forms.ModelForm):
         model = TnrisImage
         fields = ('__all__')
 
-    image_url = forms.FileField(required=False, widget=PictureWidget, help_text="Choose an image file and 'Save' this form to upload & save it to the database. Attempting to overwrite with a new file will only create a new record.")
+    image_url = forms.FileField(required=False, widget=PictureWidget, help_text="Choose an image file and 'Save' this form to upload & save it to the database. Attempting to overwrite with a new file will only create a new record. The best method to overwrite would be to delete the existing file and re-upload a new file with the same name.")
 
     # boto3 s3 object
     client = boto3.client('s3')
@@ -128,7 +128,7 @@ class DocumentForm(forms.ModelForm):
         model = TnrisDocument
         fields = ('__all__')
 
-    document_url = forms.FileField(required=False, widget=DocumentWidget, help_text="Choose a document file and 'Save' this form to upload & save it to the database. Attempting to overwrite with a new file will only create a new record.")
+    document_url = forms.FileField(required=False, widget=DocumentWidget, help_text="Choose a document file and 'Save' this form to upload & save it to the database. Attempting to overwrite with a new file will only create a new record. The best method to overwrite would be to delete the existing file and re-upload a new file with the same name.")
 
     # boto3 s3 object
     client = boto3.client('s3')

--- a/src/data_hub/tnris_org/forms.py
+++ b/src/data_hub/tnris_org/forms.py
@@ -32,7 +32,7 @@ class PictureWidget(forms.widgets.Widget):
         if value is None:
             html = Template("""<input type="file" name="$name" id="id_$name"><label for="img_$name">Current: <a href="#">$link</a></label>""")
         else:
-            html = Template("""{0}<a style="cursor:pointer;border:solid 1px;padding:3px;margin-left:15px;" onclick="copyFunction();">COPY URL</a><input style="width:50%;margin-left:5px;" type="text" id="currentUrl" value="$link" readonly></input><br><img id="img_$name" src="$link"/>""".format(js))
+            html = Template("""{0}<div style="margin-bottom:10px;"><a style="cursor:pointer;border:solid 1px;padding:3px;" onclick="copyFunction();">COPY URL</a></div><div style="margin-bottom:10px;"><input style="width:50%;" type="text" id="currentUrl" value="$link" readonly></input></div><div style="margin-bottom:10px;"><img id="img_$name" src="$link"/></div>""".format(js))
         return mark_safe(html.substitute(link=value,name=name))
 
 
@@ -51,7 +51,7 @@ class DocumentWidget(forms.widgets.Widget):
         if value is None:
             html = Template("""<input type="file" name="$name" id="id_$name"><label for="doc_$name">Current: <a href="#">$link</a></label>""")
         else:
-            html = Template("""{0}<a style="cursor:pointer;border:solid 1px;padding:3px;margin-left:15px;" onclick="copyFunction();">COPY URL</a><input style="width:50%;margin-left:5px;" type="text" id="currentUrl" value="$link" readonly></input>""".format(js))
+            html = Template("""{0}<div style="margin-bottom:10px;"><a style="cursor:pointer;border:solid 1px;padding:3px;" onclick="copyFunction();">COPY URL</a></div><div style="margin-bottom:10px;"><input style="width:50%;" type="text" id="currentUrl" value="$link" readonly></input></div>""".format(js))
         return mark_safe(html.substitute(link=value,name=name))
 
 


### PR DESCRIPTION
closes issue #64 

tiny_preview removed for documents --> was causing various console errors and auto-downloading of files for little benefit. previewing the /images makes sense and works flawlessly but there are too many one-off situations with documents and too many conflicts. easy fix is to remove preview for documents.

also prettied up the admin.py and forms.py for tnris_org images and documents with html div's and some margin styling to prevent copy url button overlap with url input. lays out spacing of items on new lines a bit better.

added some additional helper text regarding attempt to overwrite document and image files for tnris_org. 