### PR TITLE
Feature/map downloads bug

### DIFF
--- a/src/data_hub/msd/forms.py
+++ b/src/data_hub/msd/forms.py
@@ -19,7 +19,10 @@ class PictureWidget(forms.widgets.Widget):
 
 class PdfWidget(forms.widgets.Widget):
     def render(self, name, value, attrs=None):
-        html = Template("""<input type="file" name="$name" id="id_$name"><label for="img_$name" style='font-weight:bold;'>Current: $link</label>""")
+        if value:
+            html = Template("""<label for="img_$name" style='font-weight:bold;'>Current: $link</label>""")
+        else:
+            html = Template("""<input type="file" name="$name" id="id_$name"></input>""")
         return mark_safe(html.substitute(link=value,name=name))
 
 
@@ -33,7 +36,7 @@ class MapDownloadForm(forms.ModelForm):
             'label'
             )
 
-    download_url = forms.FileField(required=False, widget=PdfWidget, help_text="Upload map download file. PDF is recommended. 75MB max size.")
+    download_url = forms.FileField(required=False, widget=PdfWidget, help_text="Upload map download file. PDF is recommended. 75MB max size. Overwriting files is not allowed. Delete the record and create a new one with the new file if you are attempting to overwrite.")
 
     # FILE UPLOAD FOR DOWNLOAD FILE (PDF SUGGESTED)
     # boto3 s3 object

--- a/src/data_hub/msd/forms.py
+++ b/src/data_hub/msd/forms.py
@@ -20,7 +20,7 @@ class PictureWidget(forms.widgets.Widget):
 class PdfWidget(forms.widgets.Widget):
     def render(self, name, value, attrs=None):
         if value:
-            html = Template("""<label for="img_$name" style='font-weight:bold;'>Current: $link</label>""")
+            html = Template("""<label for="img_$name" style='font-weight:bold;'>$link</label>""")
         else:
             html = Template("""<input type="file" name="$name" id="id_$name"></input>""")
         return mark_safe(html.substitute(link=value,name=name))

--- a/src/data_hub/msd/forms.py
+++ b/src/data_hub/msd/forms.py
@@ -1,14 +1,22 @@
 from django import forms
 from django.core.exceptions import ValidationError
-# from django.db.utils import ProgrammingError
-
-from .models import MapCollection, MapDataRelate, MapDownload, MapSize, PixelsPerInch
-from lcd.models import Collection
 
 from string import Template
 from django.utils.safestring import mark_safe
 
-import boto3, os
+from django.db.utils import ProgrammingError
+from .models import (
+    MapCollection,
+    MapDataRelate,
+    MapDownload,
+    MapSize,
+    PixelsPerInch
+)
+
+import os
+import boto3
+
+from lcd.models import Collection
 
 
 class PictureWidget(forms.widgets.Widget):
@@ -19,8 +27,18 @@ class PictureWidget(forms.widgets.Widget):
 
 class PdfWidget(forms.widgets.Widget):
     def render(self, name, value, attrs=None):
+        js = """
+        <script type="text/javascript">
+            function copyFunction() {
+                var copyText = document.getElementById("currentUrl");
+                copyText.select();
+                document.execCommand("copy");
+            }
+        </script>
+        """
+
         if value:
-            html = Template("""<label for="img_$name" style='font-weight:bold;'>$link</label>""")
+            html = Template("""{0}<div style="margin-bottom:10px;"><a style="cursor:pointer;border:solid 1px;padding:3px;" onclick="copyFunction();">COPY URL</a></div><div alt="$link" style="margin-bottom:10px;"><input id="currentUrl" value="$link" readonly style="width: 80%;padding:3px;cursor:default;"></input></div>""".format(js))
         else:
             html = Template("""<input type="file" name="$name" id="id_$name"></input>""")
         return mark_safe(html.substitute(link=value,name=name))


### PR DESCRIPTION
closes issue #63 

map download file overwrites are not allowed. if there is a link value for a map download, show the copy url button and readonly input of current url value. if there is no value, allow normal file input uploads to create a new map download record.

__note__: the decision for no overwrites is based on the current functionality of how file overwrites are not allowed on tnris_org images and documents.