### PR TITLE
update materialized views on save!

### DIFF
--- a/lambda-refresh_materialized_views/lambda_function.py
+++ b/lambda-refresh_materialized_views/lambda_function.py
@@ -18,18 +18,24 @@ def lambda_handler(event, context):
     conn = psycopg2.connect(conn_string)
     cur = conn.cursor()
 
-    queries = [
-        "REFRESH MATERIALIZED VIEW collection_catalog_record with DATA;",
-        "REFRESH MATERIALIZED VIEW compiled_historical_collection with DATA;",
-        "REFRESH MATERIALIZED VIEW areas with DATA;",
-        "REFRESH MATERIALIZED VIEW resource_management with DATA;",
-        "REFRESH MATERIALIZED VIEW master_systems_display with DATA;"
-    ]
-
-    for q in queries:
-        print(q)
-        cur.execute(q)
+    if 'materialized_view' in event.keys():
+        query = "REFRESH MATERIALIZED VIEW %s with DATA;" % (event['materialized_view'])
+        print(query)
+        cur.execute(query)
         conn.commit()
+    else:
+        queries = [
+            "REFRESH MATERIALIZED VIEW collection_catalog_record with DATA;",
+            "REFRESH MATERIALIZED VIEW compiled_historical_collection with DATA;",
+            "REFRESH MATERIALIZED VIEW areas with DATA;",
+            "REFRESH MATERIALIZED VIEW resource_management with DATA;",
+            "REFRESH MATERIALIZED VIEW master_systems_display with DATA;"
+        ]
+
+        for q in queries:
+            print(q)
+            cur.execute(q)
+            conn.commit()
 
     cur.close()
     conn.close()

--- a/lambda-refresh_materialized_views/lambda_function.py
+++ b/lambda-refresh_materialized_views/lambda_function.py
@@ -1,5 +1,5 @@
 # --------------- IMPORTS ---------------
-import os, psycopg2
+import os, psycopg2, time
 
 # Database Connection Info
 database = os.environ.get('DB_NAME')
@@ -19,6 +19,8 @@ def lambda_handler(event, context):
     cur = conn.cursor()
 
     if 'materialized_view' in event.keys():
+        print('waiting 15 seconds to ensure database saves are complete...')
+        time.sleep(15)
         query = "REFRESH MATERIALIZED VIEW %s with DATA;" % (event['materialized_view'])
         print(query)
         cur.execute(query)

--- a/src/data_hub/lcd/forms.py
+++ b/src/data_hub/lcd/forms.py
@@ -24,7 +24,7 @@ from .models import (Collection,
                      UseRelate,
                      UseType,
                      XlargeSupplemental)
-import os
+import os, json
 import boto3, botocore, uuid
 
 class PictureWidget(forms.widgets.Widget):
@@ -544,6 +544,18 @@ class ResourceForm(forms.ModelForm):
         progress_tracker = [0, 0]
         super(ResourceForm, self).save(commit=False)
         return
+
+    def save(self, commit=True):
+        # fire lambda to refresh the RemView
+        client = boto3.client('lambda')
+        payload = {'materialized_view': 'resource_management'}
+        response = client.invoke(
+            FunctionName='api-tnris-org-refresh_materialized_views',
+            InvocationType='Event',
+            Payload=json.dumps(payload)
+        )
+        print(response)
+        return super(ResourceForm, self).save(commit=commit)
 
 
 class XlargeSupplementalForm(forms.ModelForm):

--- a/src/data_hub/lcd/models.py
+++ b/src/data_hub/lcd/models.py
@@ -1,5 +1,4 @@
 from django.db import models
-
 import uuid
 import boto3
 import os
@@ -483,7 +482,7 @@ class CountyRelate(models.Model):
     last_modified = models.DateTimeField('Last Modified', auto_now=True)
 
     def __str__(self):
-        return self.area_type.area_type_name
+        return self.area_type_id.area_type_name
 
 
 class EpsgRelate(models.Model):

--- a/src/data_hub/lcd/spatial_models.py
+++ b/src/data_hub/lcd/spatial_models.py
@@ -1,8 +1,6 @@
 from django.db import models
-
 import uuid
 
-from django.db import models
 
 """
 These tables might be used in future versions of this app.

--- a/src/data_hub/msd/forms.py
+++ b/src/data_hub/msd/forms.py
@@ -14,7 +14,7 @@ from .models import (
 )
 
 import os
-import boto3
+import boto3, json
 
 from lcd.models import Collection
 
@@ -115,6 +115,17 @@ class MapDownloadForm(forms.ModelForm):
                 self.handle_upload(files[f])
             else:
                 print("where did this file come from???? shouldn't be possible.")
+
+        # fire lambda to refresh the MsdView
+        client = boto3.client('lambda')
+        payload = {'materialized_view': 'master_systems_display'}
+        response = client.invoke(
+            FunctionName='api-tnris-org-refresh_materialized_views',
+            InvocationType='Event',
+            Payload=json.dumps(payload)
+        )
+        print(response)
+        
         return super(MapDownloadForm, self).save(commit=commit)
 
 
@@ -219,4 +230,15 @@ class MapCollectionForm(forms.ModelForm):
         for add in adds:
             data_collection_rec = Collection.objects.get(collection_id=add)
             MapDataRelate(data_collection_id=data_collection_rec, map_collection_id=self.instance).save()
+
+        # fire lambda to refresh the MsdView
+        client = boto3.client('lambda')
+        payload = {'materialized_view': 'master_systems_display'}
+        response = client.invoke(
+            FunctionName='api-tnris-org-refresh_materialized_views',
+            InvocationType='Event',
+            Payload=json.dumps(payload)
+        )
+        print(response)
+
         return super(MapCollectionForm, self).save(commit=commit)


### PR DESCRIPTION
updated refresh materialized view lambda to handle individual invocations. updated forms/admins to deliberately invoke lambda for the views related to tables edited in form. applies to every materialized view except 'areas'. routine lambda refresh will handle 'areas' view, and will continue to refresh all views as a routine safeguard.