### PR TITLE
Comments out obsolete code.

### DIFF
--- a/src/data_hub/dashboard.py
+++ b/src/data_hub/dashboard.py
@@ -6,7 +6,7 @@ To activate your index dashboard add the following to your settings.py::
     GRAPPELLI_INDEX_DASHBOARD = 'data_hub.dashboard.CustomIndexDashboard'
 """
 
-from django.utils.translation import ugettext_lazy as _
+# from django.utils.translation import ugettext_lazy as _
 from django.urls import reverse
 
 from grappelli.dashboard import modules, Dashboard


### PR DESCRIPTION
Missed commit which comments out a reference to the obsolete ugettext_lazy.