### PR TITLE
updating dockerfile and start_local_db.sh helper script

### DIFF
--- a/LOCAL_POSTGIS/Dockerfile
+++ b/LOCAL_POSTGIS/Dockerfile
@@ -1,6 +1,11 @@
-FROM mdillon/postgis
+FROM postgis/postgis:13-3.4
 
-COPY z_api_init.sh /docker-entrypoint-initdb.d/z_api_init.sh
-COPY z_init.sql /z_init.sql
+COPY ./z_api_init.sh /docker-entrypoint-initdb.d/11_z_api_init.sh
+COPY ./z_init.sql /z_init.sql
+
+RUN chmod +x /docker-entrypoint-initdb.d/11_z_api_init.sh
+
+## NEVER USE THIS IN PRODUCTION OR SECURITY SENSITIVE SITUATION!!!!
+ENV POSTGRES_HOST_AUTH_METHOD=trust
 
 EXPOSE 5432

--- a/LOCAL_POSTGIS/start_local_db.sh
+++ b/LOCAL_POSTGIS/start_local_db.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 
-docker build . -t tnris/api-local-postgis
-docker run -d -p 9000:5432 tnris/api-local-postgis
+docker build . -t txgio/api-local-postgis
+docker run -d -p 9000:5432 txgio/api-local-postgis


### PR DESCRIPTION
- update Dockerfile to use updated version of postgresql and postgis for compatibility with Django 4.*
- update helper script start_local_db.sh to reflect changes to Dockerfile mentioned above