### PR TITLE
Revert "Altered because replacing the s3 resource with data.tnris.org…

### DIFF
--- a/src/data_hub/lcd/admin.py
+++ b/src/data_hub/lcd/admin.py
@@ -269,8 +269,7 @@ class ResourceAdmin(admin.ModelAdmin):
     )
 
     def download_url(self, obj):
-        return obj.resource
-        #return obj.resource.replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.tnris.org/')
+        return obj.resource.replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.tnris.org/')
 
     # set aside acqusition_date year for list display
     def disp_name(self, resource):


### PR DESCRIPTION
… corrupts the crsf token in IE edge."

This reverts commit 26bae4a3460cfe0afe3c5ba004ebb357a9b6838b.