### PR TITLE
Fixes #436

### DIFF
--- a/src/data_hub/lcd/admin.py
+++ b/src/data_hub/lcd/admin.py
@@ -269,7 +269,7 @@ class ResourceAdmin(admin.ModelAdmin):
     )
 
     def download_url(self, obj):
-        return obj.resource
+        return obj.resource.replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
 
     # set aside acqusition_date year for list display
     def disp_name(self, resource):

--- a/src/data_hub/lcd/forms.py
+++ b/src/data_hub/lcd/forms.py
@@ -37,7 +37,7 @@ from PIL import Image as PilImage
 
 # widget template override for populated upload file fields
 def populated_image_render(name, value, attrs=None, renderer=None):
-    cdn_link = value
+    cdn_link = value.replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
     html = Template("""
         <div style="margin-bottom:10px;">
             <input style="width:90%;" type="text" id="currentUrl" value="$link" readonly></input>
@@ -53,7 +53,7 @@ class ZipfileWidget(forms.widgets.Widget):
     def render(self, name, value, attrs=None, renderer=None):
         cdn_link = value
         if value is not None:
-            cdn_link = value
+            cdn_link = value.replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         html = Template("""
             <input type="file" name="$name" id="id_$name"><label for="img_$name">Current: $link</label>
         """)

--- a/src/data_hub/lcd/serializers.py
+++ b/src/data_hub/lcd/serializers.py
@@ -11,7 +11,7 @@ class CatalogCollectionMetaSerializer(serializers.ModelSerializer):
     thumbnail_image = serializers.SerializerMethodField()
     def get_thumbnail_image(self, obj):
         if str(obj.thumbnail_image) != "" and obj.thumbnail_image is not None:
-            path = str(obj.thumbnail_image)
+            path = str(obj.thumbnail_image).replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         else:
             path = None
         return path
@@ -19,7 +19,7 @@ class CatalogCollectionMetaSerializer(serializers.ModelSerializer):
     tile_index_url = serializers.SerializerMethodField()
     def get_tile_index_url(self, obj):
         if str(obj.tile_index_url) != "" and obj.tile_index_url is not None:
-            path = str(obj.tile_index_url)
+            path = str(obj.tile_index_url).replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         else:
             path = None
         return path
@@ -32,7 +32,7 @@ class CollectionSerializer(serializers.ModelSerializer):
     thumbnail_image = serializers.SerializerMethodField()
     def get_thumbnail_image(self, obj):
         if str(obj.thumbnail_image) != "" and obj.thumbnail_image is not None:
-            path = str(obj.thumbnail_image)
+            path = str(obj.thumbnail_image).replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         else:
             path = None
         return path
@@ -40,7 +40,7 @@ class CollectionSerializer(serializers.ModelSerializer):
     images = serializers.SerializerMethodField()
     def get_images(self, obj):
         if str(obj.images) != "" and obj.images is not None:
-            path = str(obj.images)
+            path = str(obj.images).replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         else:
             path = None
         return path
@@ -48,7 +48,7 @@ class CollectionSerializer(serializers.ModelSerializer):
     tile_index_url = serializers.SerializerMethodField()
     def get_tile_index_url(self, obj):
         if str(obj.tile_index_url) != "" and obj.tile_index_url is not None:
-            path = str(obj.tile_index_url)
+            path = str(obj.tile_index_url).replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         else:
             path = None
         return path
@@ -56,7 +56,7 @@ class CollectionSerializer(serializers.ModelSerializer):
     supplemental_report_url = serializers.SerializerMethodField()
     def get_supplemental_report_url(self, obj):
         if str(obj.supplemental_report_url) != "" and obj.supplemental_report_url is not None:
-            path = str(obj.supplemental_report_url)
+            path = str(obj.supplemental_report_url).replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         else:
             path = None
         return path
@@ -64,7 +64,7 @@ class CollectionSerializer(serializers.ModelSerializer):
     lidar_breaklines_url = serializers.SerializerMethodField()
     def get_lidar_breaklines_url(self, obj):
         if str(obj.lidar_breaklines_url) != "" and obj.lidar_breaklines_url is not None:
-            path = str(obj.lidar_breaklines_url)
+            path = str(obj.lidar_breaklines_url).replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         else:
             path = None
         return path
@@ -72,7 +72,7 @@ class CollectionSerializer(serializers.ModelSerializer):
     lidar_buildings_url = serializers.SerializerMethodField()
     def get_lidar_buildings_url(self, obj):
         if str(obj.lidar_buildings_url) != "" and obj.lidar_buildings_url is not None:
-            path = str(obj.lidar_buildings_url)
+            path = str(obj.lidar_buildings_url).replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         else:
             path = None
         return path
@@ -85,7 +85,7 @@ class ResourceSerializer(serializers.ModelSerializer):
     resource = serializers.SerializerMethodField()
     def get_resource(self, obj):
         if str(obj.resource) != "" and obj.resource is not None:
-            path = str(obj.resource)
+            path = str(obj.resource).replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         else:
             path = None
         return path

--- a/src/data_hub/lore/forms.py
+++ b/src/data_hub/lore/forms.py
@@ -11,7 +11,7 @@ import boto3, uuid
 
 # widget template override for populated upload file fields
 def populated_image_render(name, value, attrs=None, renderer=None):
-    cdn_link = value
+    cdn_link = value.replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
     html = Template("""
         <div style="margin-bottom:10px;">
             <input style="width:90%;" type="text" id="currentUrl" value="$link" readonly></input>

--- a/src/data_hub/lore/models.py
+++ b/src/data_hub/lore/models.py
@@ -330,7 +330,7 @@ class Image(models.Model):
         super().delete(*args, **kwargs)
 
     def __str__(self):
-        return self.image_url
+        return self.image_url.replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
 
 
 """
@@ -385,7 +385,7 @@ class ChcView(models.Model):
         'Mosaic Service URL',
         max_length=256
     )
-    counties = models.TextField(
+    counties = models.TextField(.replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         'Counties'
     )
     source_name = models.CharField(

--- a/src/data_hub/lore/serializers.py
+++ b/src/data_hub/lore/serializers.py
@@ -56,7 +56,7 @@ class CollectionSerializer(serializers.ModelSerializer):
     thumbnail_image = serializers.SerializerMethodField()
     def get_thumbnail_image(self, obj):
         if str(obj.thumbnail_image) != "" and obj.thumbnail_image is not None:
-            path = str(obj.thumbnail_image)
+            path = str(obj.thumbnail_image).replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         else:
             path = None
         return path
@@ -64,7 +64,7 @@ class CollectionSerializer(serializers.ModelSerializer):
     images = serializers.SerializerMethodField()
     def get_images(self, obj):
         if str(obj.images) != "" and obj.images is not None:
-            path = str(obj.images)
+            path = str(obj.images).replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         else:
             path = None
         return path

--- a/src/data_hub/msd/serializers.py
+++ b/src/data_hub/msd/serializers.py
@@ -10,7 +10,7 @@ class MapCollectionSerializer(serializers.ModelSerializer):
     thumbnail_link = serializers.SerializerMethodField()
     def get_thumbnail_link(self, obj):
         if str(obj.thumbnail_link) != "" and obj.thumbnail_link is not None:
-            path = str(obj.thumbnail_link)
+            path = str(obj.thumbnail_link).replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         else:
             path = None
         return path
@@ -18,7 +18,7 @@ class MapCollectionSerializer(serializers.ModelSerializer):
     map_downloads = serializers.SerializerMethodField()
     def get_map_downloads(self, obj):
         if str(obj.map_downloads) != "" and obj.map_downloads is not None:
-            path = str(obj.map_downloads)
+            path = str(obj.map_downloads).replace('https://s3.amazonaws.com/data.tnris.org/', 'https://data.geographic.texas.gov/')
         else:
             path = None
         return path


### PR DESCRIPTION
- re-adds URL replacement removed in e0c37b693abb307272b70e79c9a90594830f858d, but substitutes the s3 URL with data.geographic.texas.gov instead of data.tnris.org.  The caching issues previously fixed by the commit above were fixed with a different commit.