### PR TITLE
Arcgis chart bug

### DIFF
--- a/src/data_hub/analytics/templates/stats.html
+++ b/src/data_hub/analytics/templates/stats.html
@@ -447,6 +447,41 @@
         </div>
 
         <script>
+            const getCSRFToken = () => {
+                const cookies = document.cookie.split(";");
+                let csrfToken = cookies.find((ck) =>
+                    ck.trim().startsWith("csrftoken=")
+                );
+                return decodeURIComponent(csrfToken.trim().substring(10));
+            };
+            let testBody = {
+                reportName: "rob" + Date.now(),
+                resourceURIs: ["services/", "services/Address_Points"],
+            };
+            let myPromise = fetch(
+                "http://localhost:8000/analytics/update_services_in_arcgis_report/",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "X-CSRFToken": getCSRFToken(),
+                    },
+                    body: JSON.stringify(testBody),
+                }
+            );
+            myPromise
+                .then((response) => {
+                    if (!response.ok) {
+                        throw new Error("error response" + response);
+                    }
+                    return response.json();
+                })
+                .then((data) => {
+                    console.log(data);
+                })
+                .catch((error) => {
+                    console.log("update did not work", error);
+                });
             const buildChart = (chartId, chartLabel, labels, data) => {
                 const ctx = document.getElementById(chartId);
                 new Chart(ctx, {

--- a/src/data_hub/analytics/templates/stats.html
+++ b/src/data_hub/analytics/templates/stats.html
@@ -447,41 +447,6 @@
         </div>
 
         <script>
-            const getCSRFToken = () => {
-                const cookies = document.cookie.split(";");
-                let csrfToken = cookies.find((ck) =>
-                    ck.trim().startsWith("csrftoken=")
-                );
-                return decodeURIComponent(csrfToken.trim().substring(10));
-            };
-            let testBody = {
-                reportName: "rob" + Date.now(),
-                resourceURIs: ["services/", "services/Address_Points"],
-            };
-            let myPromise = fetch(
-                "http://localhost:8000/analytics/update_services_in_arcgis_report/",
-                {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                        "X-CSRFToken": getCSRFToken(),
-                    },
-                    body: JSON.stringify(testBody),
-                }
-            );
-            myPromise
-                .then((response) => {
-                    if (!response.ok) {
-                        throw new Error("error response" + response);
-                    }
-                    return response.json();
-                })
-                .then((data) => {
-                    console.log(data);
-                })
-                .catch((error) => {
-                    console.log("update did not work", error);
-                });
             const buildChart = (chartId, chartLabel, labels, data) => {
                 const ctx = document.getElementById(chartId);
                 new Chart(ctx, {
@@ -552,42 +517,34 @@
                 });
             };
 
-            // toggle the service and update the line chart
-            // if service is null, just return the chart with
-            // whatever services are currently turned on
-            const toggleService = async (service) => {
-                const lineChartContainer =
-                    document.getElementById("line-chart-div");
-                lineChartContainer.innerHTML =
-                    "<div class='line-chart-stand-in'>Loading ...</div>";
+            const convertDateToTime = (dateString) => {
+                // assumes date string in YYYY-MM-DD format
+                if (!dateString) return;
+                const [year, month, day] = dateString.split("-");
+                return new Date(year, month - 1, day).getTime();
+            };
 
-                // build the date params, if any
+            const getQueryParam = (paramName) => {
                 const queryParams = window.location.search.split("?")[1];
-                const convertDateToTime = (dateString) => {
-                    // assumes date string in YYYY-MM-DD format
-                    const [year, month, day] = dateString.split("-");
-                    return new Date(year, month - 1, day).getTime();
-                };
-                let startDate = "";
-                let endDate = "";
                 if (queryParams) {
                     const queryParamsArray = queryParams.split("&");
-                    queryParamsArray.forEach((param) => {
-                        if (param.startsWith("start_date")) {
-                            startDate = convertDateToTime(param.split("=")[1]);
-                        }
-                        if (param.startsWith("end_date")) {
-                            endDate = convertDateToTime(param.split("=")[1]);
-                        }
-                    });
+                    const param = queryParamsArray.find((param) =>
+                        param.startsWith(paramName)
+                    );
+                    console.log(param);
+                    return param ? param.split("=")[1] : "";
                 }
-                const response = await fetch(
-                    `/analytics/get_stats_from_arcgis/?serviceToToggle=${service}&start_date=${startDate}&end_date=${endDate}`
+            };
+
+            const getCSRFToken = () => {
+                const cookies = document.cookie.split(";");
+                let csrfToken = cookies.find((ck) =>
+                    ck.trim().startsWith("csrftoken=")
                 );
+                return decodeURIComponent(csrfToken.trim().substring(10));
+            };
 
-                const result = await response.json();
-                console.log(result);
-
+            const parseArcGISReport = (result) => {
                 // retrieve the data and build the chart
                 let datasets = [];
                 if (result.report["report-data"]) {
@@ -626,6 +583,8 @@
                     );
                 }
 
+                const lineChartContainer =
+                    document.getElementById("line-chart-div");
                 if (datasets.length > 0) {
                     lineChartContainer.innerHTML =
                         "<canvas id='line-chart'></canvas>";
@@ -634,6 +593,90 @@
                     lineChartContainer.innerHTML =
                         "<div class='line-chart-stand-in'>No Services Selected.</div>";
                 }
+            };
+
+            // toggle the service and update the line chart
+            // if service is null, just return the chart with
+            // whatever services are currently turned on
+            const toggleService = async (serviceName) => {
+                console.log(serviceName);
+                const lineChartContainer =
+                    document.getElementById("line-chart-div");
+                lineChartContainer.innerHTML =
+                    "<div class='line-chart-stand-in'>Loading ...</div>";
+
+                const reportName =
+                    sessionStorage.getItem("reportName") || Date.now();
+                sessionStorage.setItem("reportName", reportName);
+
+                // build resourceURIs; these take the form "services/", "services/Address_Points", etc.
+                // also update the allServices array which shows the current status about whether a given
+                // statistics line chart is shown yet
+                const allServices = JSON.parse(
+                    sessionStorage.getItem("allServices")
+                );
+                console.log(allServices);
+                let resourceURIs = [];
+                allServices.forEach((service) => {
+                    if (service.serviceName === serviceName) {
+                        service.isShown = !service.isShown;
+                    }
+                    if (service.isShown) {
+                        resourceURIs.push(service.serviceName);
+                    }
+                    if (service.subservices) {
+                        service.subservices.forEach((subservice) => {
+                            if (subservice.serviceName === serviceName) {
+                                subservice.isShown = !subservice.isShown;
+                            }
+                            if (subservice.isShown) {
+                                resourceURIs.push(subservice.serviceName);
+                            }
+                        });
+                    }
+                });
+                console.log(allServices);
+                console.log(resourceURIs);
+                // store the updated allServices object back in session storage
+                sessionStorage.setItem(
+                    "allServices",
+                    JSON.stringify(allServices)
+                );
+
+                let updateServicesBody = {
+                    reportName,
+                    resourceURIs,
+                    startDate: convertDateToTime(getQueryParam("start_date")),
+                    endDate: convertDateToTime(getQueryParam("end_date")),
+                };
+                await fetch(
+                    "http://localhost:8000/analytics/update_services_in_arcgis_report/",
+                    {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                            "X-CSRFToken": getCSRFToken(),
+                        },
+                        body: JSON.stringify(updateServicesBody),
+                    }
+                )
+                    .then((response) => {
+                        if (!response.ok) {
+                            throw new Error("error response" + response);
+                        }
+                    })
+                    .then(async () => {
+                        const response = await fetch(
+                            `/analytics/get_stats_from_arcgis/?reportName=${reportName}`
+                        );
+
+                        const result = await response.json();
+                        console.log(result);
+                        parseArcGISReport(result);
+                    })
+                    .catch((error) => {
+                        console.log("update did not work", error);
+                    });
             };
 
             // creates the plus/minus checkbox that shows/hides the subservices div
@@ -727,11 +770,22 @@
             const getAllServices = async () => {
                 const serviceTypesDiv =
                     document.getElementById("service-types");
-                const response = await fetch(
-                    "/analytics/get_all_services_and_subservices/"
+                let allServices = JSON.parse(
+                    sessionStorage.getItem("allServices")
                 );
-                allServices = await response.json();
+                if (!allServices) {
+                    const response = await fetch(
+                        "/analytics/get_all_services_and_subservices/"
+                    );
+                    allServices = await response.json();
+
+                    sessionStorage.setItem(
+                        "allServices",
+                        JSON.stringify(allServices)
+                    );
+                }
                 console.log(allServices);
+
                 allServices.forEach(async (service) => {
                     const subservicesDiv = createSubservicesDiv(
                         service.serviceName,

--- a/src/data_hub/analytics/urls.py
+++ b/src/data_hub/analytics/urls.py
@@ -5,5 +5,6 @@ from . import views
 urlpatterns = [
     path('get_monthly_stats/', views.get_monthly_stats),
     path('get_all_services_and_subservices/', views.get_all_service_and_subservices),
+    path('update_services_in_arcgis_report/', views.update_services_in_arcgis_report),
     path('get_stats_from_arcgis/', views.get_stats_from_arcgis)
 ]

--- a/src/data_hub/analytics/views.py
+++ b/src/data_hub/analytics/views.py
@@ -59,13 +59,13 @@ def get_arcgis_token():
 def get_all_service_and_subservices(request):
     # initialize the list of services and subservices and their shown status
     global all_services
-    # if all_services is not None:
-    #     return JsonResponse(all_services, safe=False)
+    if all_services is not None:
+        return JsonResponse(all_services, safe=False)
     
     token = get_arcgis_token()    
-    response = requests.get('https://feature.geographic.texas.gov/arcgis/admin/usagereports/analytics_dashboard?f=json&token=' + token)
-    currentServices = response.json()["queries"][0]["resourceURIs"]
-    print("currentServices " + str(currentServices))
+    # response = requests.get('https://feature.geographic.texas.gov/arcgis/admin/usagereports/analytics_dashboard?f=json&token=' + token)
+    # currentServices = response.json()["queries"][0]["resourceURIs"]
+    # print("currentServices " + str(currentServices))
 
     all_services = [
         {  "serviceName": "services/", "isShown": True },
@@ -79,6 +79,7 @@ def get_all_service_and_subservices(request):
         {  "serviceName": "services/Parcels", "isShown": False }
     ]
     for s in all_services:
+        print("serviceName")
         print(s["serviceName"])
         # if s["serviceName"] in currentServices:
         #     s["isShown"] = True
@@ -90,12 +91,58 @@ def get_all_service_and_subservices(request):
         # print(response.text)
         s["subservices"] = []
         for subservice in response.json()["services"]:
+            print("subserviceName")
             print(subservice["serviceName"])
             subserviceFullName = s["serviceName"] + "/" + subservice["serviceName"] + ".MapServer"
             # isShown = subserviceFullName in currentServices
             s["subservices"].append({"serviceName": subserviceFullName, "isShown": False})
             
     return JsonResponse(all_services, safe=False)
+
+@login_required(login_url='/admin/login/')
+def update_services_in_arcgis_report(request):
+    print("in update services")
+    token = get_arcgis_token()
+    print("reportName from request" + str(request.POST.get("reportName")))
+    reportName = request.POST.get("reportName")
+    resourceURIs = request.POST.get("resourceURIs")
+    print("request method is ")
+    print(request.method)
+    print(reportName)
+    print(resourceURIs)
+
+    # default_dates = get_default_start_and_end_dates()
+    # start_date = request.POST.get('start_date', default=round(default_dates[0].timestamp() / 100) * 100000)
+    # end_date = request.POST.get('end_date', default=round(default_dates[1].timestamp() / 100) * 100000)
+    # # for some reason, the default argument isn't working, so using the code below
+    # if (not start_date): 
+    #     start_date = str(round(default_dates[0].timestamp() / 100) * 100000)
+    # if (not end_date): 
+    #     end_date = str(round(default_dates[1].timestamp() / 100) * 100000)
+    # print('from', start_date)
+    # print('to', end_date)
+
+
+    # queries ='"queries":[]'
+    # if len(resourceURIs) > 0:
+    #     queries = '"queries":[{"resourceURIs":' + str(resourceURIs) + ',"metrics":["RequestCount"]}]'
+    # print("queries " + queries)
+    # data = {'usagereport': '{"reportname":"' + reportName + '","since":"CUSTOM",' + str(queries) + ',"metadata":{"temp":false,"title":"Total requests for the last 7 days","managerReport":true,"styles":{"services/":{"color":"#D900D9"}}},"from":' + str(start_date) + ',"to":' + str(end_date) + '}', 'f': 'json', 'token': token}
+    # print("edit data " + str(data))
+
+    # response = requests.get('https://feature.geographic.texas.gov/arcgis/admin/usagereports/' + reportName + '?f=json&token=' + token)
+    # print("first request " + response.status_code)
+    # # check if 404 error    
+    # if (response.status_code == 404):
+    #     response = requests.post('https://feature.geographic.texas.gov/arcgis/admin/usagereports/add', data=data)
+    # else:
+    #     response = requests.post('https://feature.geographic.texas.gov/arcgis/admin/usagereports/analytics_dashboard/edit', data=data)
+
+    # print(response.txt)
+    return HttpResponse("OK")
+
+    # When update successfully returns, call get stats from arcgis.  
+    # tear out all the code to edit the report
 
 @login_required(login_url='/admin/login/')
 def get_stats_from_arcgis(request):
@@ -108,6 +155,7 @@ def get_stats_from_arcgis(request):
     # toggle the service listed in the request and 
     # add any shown service to the list of resourceURIs
     serviceToToggle = request.GET.get("serviceToToggle")
+    print("service to toggle")
     print(serviceToToggle)
     resourceURIs = []
     for service in all_services:


### PR DESCRIPTION
Modifies the code to break getting ArcGIS reports into two functions, one to update the report in ArcGIS and one to run it and retrieve the results.

The current status showing which reports are turned on is stored on the client side in session storage, along with the report name.  A list of the report URIs ("service/", "service/Address_Points", etc.) which are activated is sent to the analytics view, along with the report name.  If updating is a success, the results are retrieved and the line chart is constructed.  Previously, the same report was used for all users and it got out of sync.

Additionally, some functionality in the template was broken out into separate functions.