### PR TITLE
Use environment variables to centralize urls.

### DIFF
--- a/src/data_hub/contact/fdms/fiserv_helper.py
+++ b/src/data_hub/contact/fdms/fiserv_helper.py
@@ -250,15 +250,3 @@ def generate_level_three(f_total_amount, f_tran_fee):
             "unitofmeasure": "EA",
         },
     ]
-
-def authenticate_lambda():
-    """
-    Check CCP ACCESS CODE to prevent bots from making requests.
-    """
-        if os.environ.get("CCP_ACCESS_CODE") != request.data["access_code"]:
-            if api_helper.checkLogger():
-                logger.error("CCP access code incorrect")
-            return Response(
-                {"status": "access_denied", "message": "access_denied"},
-                status=status.HTTP_401_UNAUTHORIZED,
-            )

--- a/src/data_hub/contact/tests.py
+++ b/src/data_hub/contact/tests.py
@@ -121,9 +121,9 @@ order_details = {
 
 PROTOCOL = "http"
 
-FISERV_URL = "https://snappaydirectapi-cert.fiserv.com/api/interop/"
-FISERV_URL_V2 = "https://snappaydirectapi-cert.fiserv.com/api/interop/v2/"
-FISERV_URL_V3 = "https://snappaydirectapi-cert.fiserv.com/api/interop/v3/"
+FISERV_URL = str(os.environ.get("FISERV_URL"))
+FISERV_URL_V2 = str(os.environ.get("FISERV_URL_V2"))
+FISERV_URL_V3 = str(os.environ.get("FISERV_URL_V3"))
 SEND_EMAIL = "N"
 payload_valid_test = fiserv_helper.generate_fiserv_post_body("CC", "", 1092, 11.11, .50,  order_details)
 

--- a/src/data_hub/contact/viewsets.py
+++ b/src/data_hub/contact/viewsets.py
@@ -198,7 +198,7 @@ class FiservInitiateRetentionCleanupViewSet(fiserv_payments.InitiateRetentionCle
     def create(self, request):
        return self.intro(request, "running InitiateRetentionCleanupViewSet")
 
-class FiservOrderArchivalViewSet(fiserv_payments.OrderArchivalViewSetSuper):
+class FiservOrderArchivalViewSet(viewsets.ViewSet):
     """
     Order archival viewset.
     """

--- a/src/data_hub/modules/api_helper.py
+++ b/src/data_hub/modules/api_helper.py
@@ -16,7 +16,6 @@ logger.addHandler(watchtower.CloudWatchLogHandler())
 
 SHOULD_LOG = False
 LAST_CHECKED = 0
-FISERV_URL = "https://snappaydirectapi-cert.fiserv.com/api/interop/"
 
 def authenticate_lambda(access_code):
     """


### PR DESCRIPTION
remove authenticate_lambda from fiserv_helper, check order archived in retention cleanup. OrderArchivalViewSetSuper no longer exists so deprecate route.